### PR TITLE
fix: remove unnecessary cap prefix

### DIFF
--- a/deploy/charts/checkmk/templates/node-collector-container-metrics-psp.yaml
+++ b/deploy/charts/checkmk/templates/node-collector-container-metrics-psp.yaml
@@ -14,7 +14,7 @@ metadata:
     apparmor.security.beta.kubernetes.io/defaultProfileName: >-
       runtime/default
 spec:
-  allowedCapabilities: [CAP_SYS_PTRACE]
+  allowedCapabilities: [SYS_PTRACE]
   allowedHostPaths:
     - pathPrefix: /var/run
       readOnly: false

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -188,7 +188,7 @@ nodeCollector:
       capabilities:
         drop:
           - ALL
-        add: ["CAP_SYS_PTRACE"]
+        add: ["SYS_PTRACE"]
       privileged: false
       readOnlyRootFilesystem: true
 


### PR DESCRIPTION
collides with older versions of docker which do not support having the prefix already