### PR TITLE
Fix custom cluster allow ingress NetworkPolicy

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-netpol.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-netpol.yaml
@@ -103,9 +103,9 @@ spec:
     - Ingress
   ingress:
     - from:
-      {{- range $v := .Values.networkPolicy.allowIngressFromCIDRs }}
+      {{- range $cidr := .Values.networkPolicy.allowIngressFromCIDRs }}
       - ipBlock:
-          cidr: '$v'
+          cidr: {{ .cidr }}
       {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes the custom cluster allow ingress NetworkPolicy
https://kubernetes.io/docs/concepts/services-networking/network-policies/
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicyingressrule-v1-networking-k8s-io