### PR TITLE
Add debug Output

### DIFF
--- a/src/checkmk_kube_agent/send_metrics.py
+++ b/src/checkmk_kube_agent/send_metrics.py
@@ -373,6 +373,7 @@ def machine_sections_worker(
         ["/usr/local/bin/check_mk_agent"],
         stdout=subprocess.PIPE,
     ) as process:
+        logger.debug(process.stdout.read()) 
         returncode = process.wait(5)
         if returncode != 0:
             # we don't capture stderr so it's printed to stderr of this process


### PR DESCRIPTION
A positive sideeffect is that this PR fixes a bug: https://forum.checkmk.com/t/crashbackloopoff-for-node-collector-machine-sections-on-large-nodes/35531/2

`ssubprocess` can't convert '_io.BufferedReader' object to str implicitly, so reading the stdout before it gets processed fixes this bug