### PR TITLE
[Helm chart] Allow specification of annotations in cluster-collector-svc

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-svc.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "checkmk.labels" . | nindent 4 }}
     app: {{ include "checkmk.fullname" . }}-cluster-collector
+  {{- with .Values.clusterCollector.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.clusterCollector.service.type }}
   ports:

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -8,7 +8,7 @@ kubeVersionOverride: ""
 
 tlsCommunication:
   enabled: false
-  verifySsl: false 
+  verifySsl: false
   # clusterCollectorKey: |-
   #   -----BEGIN EC PRIVATE KEY-----
   #   XYZ
@@ -109,6 +109,7 @@ clusterCollector:
     type: ClusterIP
     port: 8080
     # nodePort: 30035
+    annotations: {}
 
   ingress:
     enabled: false


### PR DESCRIPTION
For some use cases it is required to specify annotations on the Kubernetes service object for the cluster collector (`cluster-collector-svc`).

Example:
```yaml
    annotations:
      cloud.google.com/neg: '{"ingress": true}'
      cloud.google.com/backend-config: '{"default": "my-backendconfig"}'
```
So this capability was added. Annotations can be specified via `.Values.clusterCollector.service.annotations`.
Default value is an empty map.