### PR TITLE
[Helm Chart] Add BackendConfig to support custom GCE ingress health checks

### DIFF
--- a/deploy/charts/checkmk/templates/cluster-collector-backendconfig.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-backendconfig.yaml
@@ -1,0 +1,17 @@
+---
+{{- if .Values.clusterCollector.service.gkeBackendConfigEnabled -}}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "checkmk.fullname" . }}-cluster-collector
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    port: {{ .Values.clusterCollector.containerPort | default 10050 }}
+    {{- if .Values.tlsCommunication.enabled }}
+    type: "HTTPS"
+    {{- else }}
+    type: "HTTP"
+    {{- end }}
+    requestPath: {{ .Values.clusterCollector.livenessProbe.path | default "/health" }}
+{{- end }}

--- a/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
+++ b/deploy/charts/checkmk/templates/cluster-collector-deploy.yaml
@@ -61,7 +61,7 @@ spec:
                   fieldPath: spec.nodeName
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.clusterCollector.livenessProbe.path | default "/health" }}
               port: api
               httpHeaders:
                 - name: status
@@ -78,7 +78,7 @@ spec:
           resources:
             {{- toYaml .Values.clusterCollector.resources | nindent 12 }}
           ports:
-            - containerPort: 10050
+            - containerPort: {{ .Values.clusterCollector.containerPort | default 10050 }}
               name: api
               protocol: TCP
           volumeMounts:

--- a/deploy/charts/checkmk/values.yaml
+++ b/deploy/charts/checkmk/values.yaml
@@ -87,6 +87,8 @@ clusterCollector:
   # can be: "debug", "info", "warning" (default), "critical"
   logLevel: warning
 
+  containerPort: 10050
+
   podAnnotations:
     seccomp.security.alpha.kubernetes.io/pod: runtime/default
 
@@ -110,6 +112,7 @@ clusterCollector:
     port: 8080
     # nodePort: 30035
     annotations: {}
+    gkeBackendConfigEnabled: false
 
   ingress:
     enabled: false
@@ -131,6 +134,7 @@ clusterCollector:
     periodSeconds: 10
     timeoutSeconds: 2
     failureThreshold: 3
+    path: /health
 
   resources:
     limits:


### PR DESCRIPTION
As mentioned in #16 ([this comment](https://github.com/tribe29/checkmk_kube_agent/pull/16#issuecomment-1460092881)), when using a `gce-internal` ingress on Google Kubernetes Engine, there may be the need to specify a custom health check.

In GKE this is done via a [cloud.google.com/v1.BackendConfig](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#direct_hc) object.

Changes of this PR:
* Allow specification of a custom gce-internal Health check by using BackendConfig
  * BackendConfig object is optional and can be toggled by value `clusterCollector.service.gkeBackendConfigEnabled`
* Added prerequisites to do so, i.e.
  * Make containerPort of cluster-collector Pods configurable (value `clusterCollector.containerPort`)
    * Default value `10050`
  * Make health check path of livenessProbe configurable (value `clusterCollector.livenessProbe.path`)
    * Default value `"/health"`