### PR TITLE
feat: Add cache size to DedupTTLCache and log cache stats

### DIFF
--- a/src/checkmk_kube_agent/api.py
+++ b/src/checkmk_kube_agent/api.py
@@ -305,7 +305,7 @@ def update_container_metrics(
     
     # Log at appropriate level based on utilization
     if cache_utilization >= 95.0:
-        LOGGER.critical(
+        logger.critical(
             "Container metrics cache CRITICAL: received=%d, cache_size=%d/%d (%.1f%% full) - "
             "Cache is nearly full! Metrics are being evicted. Increase --cache-maxsize urgently.",
             len(metrics.container_metrics),
@@ -314,7 +314,7 @@ def update_container_metrics(
             cache_utilization,
         )
     elif cache_utilization >= 80.0:
-        LOGGER.error(
+        logger.error(
             "Container metrics cache WARNING: received=%d, cache_size=%d/%d (%.1f%% full) - "
             "Cache utilization high. Consider increasing --cache-maxsize.",
             len(metrics.container_metrics),
@@ -323,7 +323,7 @@ def update_container_metrics(
             cache_utilization,
         )
     else:
-        LOGGER.debug(
+        logger.debug(
             "Container metrics updated: received=%d, cache_size=%d/%d (%.1f%% full)",
             len(metrics.container_metrics),
             cache_size,

--- a/src/checkmk_kube_agent/api.py
+++ b/src/checkmk_kube_agent/api.py
@@ -305,7 +305,7 @@ def update_container_metrics(
     
     # Log at appropriate level based on utilization
     if cache_utilization >= 95.0:
-        logger.critical(
+        LOGGER.critical(
             "Container metrics cache CRITICAL: received=%d, cache_size=%d/%d (%.1f%% full) - "
             "Cache is nearly full! Metrics are being evicted. Increase --cache-maxsize urgently.",
             len(metrics.container_metrics),
@@ -314,7 +314,7 @@ def update_container_metrics(
             cache_utilization,
         )
     elif cache_utilization >= 80.0:
-        logger.error(
+        LOGGER.error(
             "Container metrics cache WARNING: received=%d, cache_size=%d/%d (%.1f%% full) - "
             "Cache utilization high. Consider increasing --cache-maxsize.",
             len(metrics.container_metrics),
@@ -323,7 +323,7 @@ def update_container_metrics(
             cache_utilization,
         )
     else:
-        logger.debug(
+        LOGGER.debug(
             "Container metrics updated: received=%d, cache_size=%d/%d (%.1f%% full)",
             len(metrics.container_metrics),
             cache_size,
@@ -458,6 +458,13 @@ def _init_app_state(
 def main(argv: Optional[Sequence[str]] = None) -> None:
     """Cluster collector API main function: start API"""
     args = parse_arguments(argv or sys.argv[1:])
+
+    # Configure application logging
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
 
     _init_app_state(
         app,

--- a/src/checkmk_kube_agent/dedup_ttl_cache.py
+++ b/src/checkmk_kube_agent/dedup_ttl_cache.py
@@ -86,3 +86,13 @@ class DedupTTLCache(TTLCache[K, V]):
         """Get all entries from the TTL cache."""
         with self.__lock:
             return list(self.values())
+
+    def size(self) -> int:
+        """Get the current number of entries in the cache."""
+        with self.__lock:
+            return len(self)
+
+    def utilization(self) -> float:
+        """Get the cache utilization as a percentage (0.0 to 100.0)."""
+        with self.__lock:
+            return (len(self) / self.maxsize) * 100.0

--- a/test_cache_size.py
+++ b/test_cache_size.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Simple test to verify DedupTTLCache size() and utilization() methods work correctly."""
+
+import sys
+sys.path.insert(0, 'src')
+
+from checkmk_kube_agent.dedup_ttl_cache import DedupTTLCache
+
+# Create a small cache for testing
+cache = DedupTTLCache(
+    key=lambda x: x[0],
+    maxsize=10,
+    ttl=60
+)
+
+print("Testing DedupTTLCache size and utilization methods:")
+print("=" * 50)
+
+# Test 1: Empty cache
+print(f"\n1. Empty cache:")
+print(f"   Size: {cache.size()}")
+print(f"   Utilization: {cache.utilization():.1f}%")
+assert cache.size() == 0
+assert cache.utilization() == 0.0
+
+# Test 2: Add some entries
+print(f"\n2. After adding 3 entries:")
+cache.put(("foo", "bar"))
+cache.put(("baz", "qux"))
+cache.put(("hello", "world"))
+print(f"   Size: {cache.size()}")
+print(f"   Utilization: {cache.utilization():.1f}%")
+assert cache.size() == 3
+assert cache.utilization() == 30.0
+
+# Test 3: Add duplicate (should not increase size)
+print(f"\n3. After adding duplicate 'foo':")
+cache.put(("foo", "updated"))
+print(f"   Size: {cache.size()}")
+print(f"   Utilization: {cache.utilization():.1f}%")
+assert cache.size() == 3
+assert cache.utilization() == 30.0
+
+# Test 4: Fill cache to capacity
+print(f"\n4. After filling to capacity (10 entries):")
+for i in range(7):
+    cache.put((f"key{i}", f"value{i}"))
+print(f"   Size: {cache.size()}")
+print(f"   Utilization: {cache.utilization():.1f}%")
+assert cache.size() == 10
+assert cache.utilization() == 100.0
+
+# Test 5: Exceed capacity (oldest should be evicted)
+print(f"\n5. After exceeding capacity:")
+cache.put(("new", "entry"))
+print(f"   Size: {cache.size()}")
+print(f"   Utilization: {cache.utilization():.1f}%")
+assert cache.size() == 10  # Should still be 10
+assert cache.utilization() == 100.0
+
+print("\n" + "=" * 50)
+print("✅ All tests passed!")
+print("\nThese methods can now be used in the API to log cache statistics.")


### PR DESCRIPTION
Add cache monitoring and alerting for container metrics

Added cache size monitoring to the cluster collector to detect and alert when the container metrics cache approaches capacity, preventing silent metric data loss.

Changes:
- Added size() and utilization() methods to DedupTTLCache to report current cache usage
- Enhanced update_container_metrics endpoint with tiered logging:
  - DEBUG: Normal operations (< 80% full)
  - ERROR: High utilization warning (80-94% full)
  - CRITICAL: Cache nearly full alert (≥ 95% full)
- All log messages include cache_size, maxsize, and utilization percentage
- Alerts provide actionable guidance to increase --cache-maxsize

This makes cache exhaustion visible at default log levels (previously silent) and helps operators identify when cache capacity needs to be increased.